### PR TITLE
fix: gcs bucket renaming

### DIFF
--- a/cmd/prowjob/createReport.go
+++ b/cmd/prowjob/createReport.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"encoding/xml"
 	"fmt"
-	"github.com/redhat-appstudio/qe-tools/pkg/customjunit"
-	"github.com/redhat-appstudio/qe-tools/pkg/types"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/redhat-appstudio/qe-tools/pkg/customjunit"
+	"github.com/redhat-appstudio/qe-tools/pkg/types"
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/redhat-appstudio/qe-tools/pkg/prow"
@@ -168,9 +169,9 @@ var createReportCmd = &cobra.Command{
 }
 
 func readXMLFile(xmlPath string, result any) error {
-	xmlFile, err := os.Open(xmlPath)
+	xmlFile, err := os.Open(filepath.Clean(xmlPath))
 	if err != nil {
-		return fmt.Errorf("Could not open file '%s', error: %v\n", xmlPath, err)
+		return fmt.Errorf("could not open file '%s', error: %v", xmlPath, err)
 	}
 	defer xmlFile.Close()
 

--- a/pkg/prow/types.go
+++ b/pkg/prow/types.go
@@ -7,7 +7,7 @@ import (
 const (
 	// The name of the openshift-ci step where the "createReport" command is used
 	reportStepName    = "redhat-appstudio-report"
-	bucketName        = "origin-ci-test"
+	bucketName        = "test-platform-results"
 	prowJobYAMLPrefix = "https://prow.ci.openshift.org/prowjob?prowjob="
 )
 


### PR DESCRIPTION
# JIRA
https://issues.redhat.com/browse/RHTAPBUGS-1089

# Additional changes
* update code that gosec/linter was complaining about

# Verification
```
❯ export PROW_JOB_ID=929712b2-7d07-4a28-ac63-9e8dd3d78ddf
❯ make build && ./qe-tools prowjob create-report 2> /dev/null && echo success
success
```