### PR TITLE
feat: omit system-err from passed test cases

### DIFF
--- a/cmd/prowjob/createReport.go
+++ b/cmd/prowjob/createReport.go
@@ -129,6 +129,16 @@ var createReportCmd = &cobra.Command{
 		overallJUnitSuites.Errors += openshiftCiJunit.Errors
 		overallJUnitSuites.Tests += openshiftCiJunit.Tests
 
+		// Omit system-err from passed test cases
+		for i := range overallJUnitSuites.TestSuites {
+			for j := range overallJUnitSuites.TestSuites[i].TestCases {
+				tc := &overallJUnitSuites.TestSuites[i].TestCases[j]
+				if tc.Status == "passed" {
+					tc.SystemErr = ""
+				}
+			}
+		}
+
 		generatedJunitFilepath := filepath.Clean(artifactDir + "/junit.xml")
 		outFile, err := os.Create(generatedJunitFilepath)
 		if err != nil {


### PR DESCRIPTION
Answer to https://github.com/redhat-appstudio/qe-tools/pull/43#issuecomment-1904124688

This PR omits the unnecessary `system-err` field in test cases with `passed` status.
I don't think there is an easy enough way to do it without the for loop.
Tested by looking at the generated report file and seeing that test cases with `passed` status have no `system-err` field while some test cases with `skipped` field do have it.