### PR TITLE
fix: modify healthCheck.go to read quay status from status.redhat.com

### DIFF
--- a/config/health-check/config.yaml
+++ b/config/health-check/config.yaml
@@ -9,7 +9,7 @@ externalServices:
       - Registry
       - API
       - Build System
-    statusPageURL: https://status.quay.io/api/v2/summary.json
+    statusPageURL: https://status.redhat.com/api/v2/summary.json
   - name: github
     criticalComponents:
       - Git Operations


### PR DESCRIPTION
Following to story  [KONFLUX-2036](https://issues.redhat.com/browse/KONFLUX-2036) , we want to modify so helatchCheck report the status of quay.io from  status.redhat.com