### PR TITLE
chore: healthcheck: +"registry.connect.redhat.com"

### DIFF
--- a/config/health-check/config.yaml
+++ b/config/health-check/config.yaml
@@ -3,6 +3,7 @@ externalServices:
     criticalComponents:
       - registry.redhat.io
       - registry.access.redhat.com
+      - registry.connect.redhat.com
     statusPageURL: https://status.redhat.com/api/v2/summary.json
   - name: quay
     criticalComponents:


### PR DESCRIPTION
the minio operator, which is installed as a part of konflux, has an image hosted on "registry.connect.redhat.com"

due to that adding that container registry to the list of critical components for the health check makes sense

([more details](https://issues.redhat.com/browse/RHTAPBUGS-1123?focusedId=24090582&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24090582))