### PR TITLE
fix: create coffee-break PR instead of push to main

### DIFF
--- a/.github/workflows/coffee.yml
+++ b/.github/workflows/coffee.yml
@@ -7,30 +7,33 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: 
+    container:
       image: golang:1.19
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        repository: 'redhat-appstudio/qe-tools'
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          repository: 'redhat-appstudio/qe-tools'
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
 
-    - name: Setup Go environment
-      uses: actions/setup-go@v5
+      - name: Run Test and Send Slack Message
+        run: go run main.go coffee-break
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          HACBS_CHANNEL_ID: ${{ secrets.HACBS_CHANNEL_ID }}
 
-    - name: Run Test and Send Slack Message
-      run: go run main.go coffee-break
-      env:
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        HACBS_CHANNEL_ID: ${{ secrets.HACBS_CHANNEL_ID }}
-
-    - name: Commit and push if it's not a Pull Request
-      run: |
-        git config --global --add safe.directory /__w/qe-tools/qe-tools
-        git init /__w/qe-tools/qe-tools
-        git config user.name "GitHub Action"
-        git config user.email "action@github.com"
-        git add config/coffee-break/last_week.txt
-        git commit -m "Update config/coffee-break/last_week.txt"
-        git push origin main -f
+      - name: Commit and create PR
+        run: |
+          git config --global --add safe.directory /__w/qe-tools/qe-tools
+          git init /__w/qe-tools/qe-tools
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git switch -c $GITHUB_JOB
+          git add config/coffee-break/last_week.txt
+          git commit -m "chore: Update config/coffee-break/last_week.txt"
+          git push -u origin HEAD
+          gh pr create -t "Add last Coffee Break" -b "Created automatically by a GitHub Action." --fill
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The main branch was recently changed to protected. The coffee-break GitHub Action used to push to main, now it creates a PR.

Tested locally using act. https://github.com/redhat-appstudio/qe-tools/pull/74