### PR TITLE
chore: add last coffee break group manually

### DIFF
--- a/config/coffee-break/last_week.txt
+++ b/config/coffee-break/last_week.txt
@@ -4,3 +4,4 @@ nshprai, kalem, sselvan
 jinqi, djodha, psturc
 kalem, nshprai, chuo
 sselvan, djodha, psturc
+kalem, nshprai, chuo


### PR DESCRIPTION
The GitHub Action failed last time, add the last group manually.