### PR TITLE
feat: add estimate time to review PR command and GH action

### DIFF
--- a/.github/workflows/estimate-review.yml
+++ b/.github/workflows/estimate-review.yml
@@ -1,0 +1,54 @@
+name: Estimate-review
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  estimate:
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.19
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          repository: 'redhat-appstudio/qe-tools'
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+
+      - name: Run estimate time needed for PR review
+        run: |
+          go run main.go estimate-review \
+            --owner ${{ github.repository_owner }} \
+            --repository ${{ github.event.repository.name }} \
+            --number ${{ github.event.pull_request.number }} \
+            > result
+          cat result
+
+      - name: Add label based on review time
+        run: |
+          reviewTime=$(cat result)
+          label="< 1 min"
+          if [ ${reviewTime} -gt 3600 ]; then
+            label="> 60 min"
+          elif [ ${reviewTime} -gt 1800 ]; then
+            label="30-60 min"
+          elif [ ${reviewTime} -gt 900 ]; then
+            label="15-30 min"
+          elif [ ${reviewTime} -gt 600 ]; then
+            label="10-15 min"
+          elif [ ${reviewTime} -gt 300 ]; then
+            label="5-10 min"
+          elif [ ${reviewTime} -gt 60 ]; then
+            label="1-5 min"
+          fi
+          
+          echo "Adding label: ${label}"
+          curl -s --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d "[\"${label}\"]"

--- a/cmd/estimate/reviewTime.go
+++ b/cmd/estimate/reviewTime.go
@@ -1,0 +1,124 @@
+package estimate
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-github/v56/github"
+	"github.com/spf13/cobra"
+	"regexp"
+)
+
+const (
+	base     = 1
+	deletion = base / 2.0
+)
+
+var estimates = map[string]float64{
+	"go":  1,
+	"sum": 0.1,
+	"mod": 0.5,
+
+	"sh": 1.5,
+
+	"yml":  2,
+	"yaml": 2,
+	"json": 2,
+
+	"md": 0.2,
+}
+
+var (
+	owner      string
+	repository string
+	prNumber   int
+
+	human bool
+)
+
+var EstimateTimeToReviewCmd = &cobra.Command{
+	Use:   "estimate-review",
+	Short: "Estimate time needed to review a PR in seconds",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		review, err := EstimateTimeToReview(owner, repository, prNumber)
+		if err != nil {
+			return err
+		}
+		if human {
+			fmt.Printf("Estimated time to review %s/%s#%d is %d seconds (~%d minutes)\n", owner, repository, prNumber, review, review/60)
+		} else {
+			fmt.Println(review)
+		}
+		return nil
+	},
+}
+
+func EstimateTimeToReview(owner, repository string, number int) (int, error) {
+	client := github.NewClient(nil)
+
+	files, err := getChangedFiles(client, owner, repository, number)
+	if err != nil {
+		return -1, err
+	}
+
+	commitCount, err := countCommits(client, owner, repository, number)
+	if err != nil {
+		return -1, err
+	}
+
+	commitCoefficient := 1 + 0.1*(float64(commitCount)-1)
+	fileCoefficient := 1 + 0.1*(float64(len(files))-1)
+	if commitCoefficient > 2 {
+		commitCoefficient = 2
+	}
+	if fileCoefficient > 2 {
+		fileCoefficient = 2
+	}
+
+	result := int(commitCoefficient * fileCoefficient * float64(estimateFileTimes(files)))
+	return result, nil
+}
+
+func countCommits(client *github.Client, owner, repository string, number int) (int, error) {
+	commits, _, err := client.PullRequests.ListCommits(context.Background(), owner, repository, number, nil)
+	return len(commits), err
+}
+
+func getChangedFiles(client *github.Client, owner, repository string, number int) ([]*github.CommitFile, error) {
+	files, _, err := client.PullRequests.ListFiles(context.Background(), owner, repository, number, nil)
+	return files, err
+}
+
+func getFileExtension(filename string) string {
+	regex := regexp.MustCompile(`\.[^.]*$`)
+	return regex.FindString(filename)
+}
+
+func estimateFileTimes(files []*github.CommitFile) int {
+	var result float64 = 0
+	for _, file := range files {
+		extension := getFileExtension(file.GetFilename())
+		if len(extension) > 0 {
+			extension = extension[1:]
+		}
+		estimate := estimates[extension]
+		if estimate == 0 {
+			estimate = 2
+		}
+
+		result += float64(file.GetAdditions()) * estimate * base
+		result += float64(file.GetDeletions()) * estimate * deletion
+	}
+	return int(result)
+}
+
+func init() {
+	EstimateTimeToReviewCmd.Flags().StringVar(&owner, "owner", "redhat-appstudio", "owner of the repository")
+	EstimateTimeToReviewCmd.Flags().StringVar(&repository, "repository", "e2e-tests", "name of the repository")
+	EstimateTimeToReviewCmd.Flags().IntVar(&prNumber, "number", 1, "number of the pull request")
+	err := EstimateTimeToReviewCmd.MarkFlagRequired("number")
+	if err != nil { // silence golangci-lint
+		return
+	}
+
+	EstimateTimeToReviewCmd.Flags().BoolVar(&human, "human", false, "human readable form")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/redhat-appstudio/qe-tools/cmd/estimate"
 	"github.com/redhat-appstudio/qe-tools/cmd/webhook"
 	"os"
 
@@ -47,6 +48,7 @@ func init() {
 	rootCmd.AddCommand(coffeebreak.CoffeeBreakCmd)
 	rootCmd.AddCommand(sendslackmessage.SendSlackMessageCmd)
 	rootCmd.AddCommand(webhook.WebhookCmd)
+	rootCmd.AddCommand(estimate.EstimateTimeToReviewCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
- Add command for estimation of the time it takes to review a pull
request.
- Add GitHub Action for running the time needed for PR review estimation and adding a label to the PR
- Tested in https://github.com/tnevrlka/qe-tools/pull/4

Examples:
- https://github.com/redhat-appstudio/e2e-tests/pull/971 -> estimated < 1 minute
- https://github.com/redhat-appstudio/e2e-tests/pull/1016 -> estimated ~4 minutes
- https://github.com/redhat-appstudio/e2e-tests/pull/1040 -> estimated ~7 minutes
-  https://github.com/redhat-appstudio/build-definitions/pull/791 -> estimated ~149 minutes (2.5 hours)