### PR TITLE
feat(KONFLUX-2072): prepare the pkg to be able to detect issues outside e2e workflow

### DIFF
--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -173,7 +173,10 @@ func (as *ArtifactScanner) processRequiredFile(fullArtifactName, artifactDirecto
 		return nil
 	}
 
-	fileName := getFileName(fullArtifactName, artifactDirectoryPrefix)
+	fileName, err := getFileName(fullArtifactName, artifactDirectoryPrefix)
+	if err != nil {
+		return err
+	}
 
 	if err := as.initArtifactStepMap(context.Background(), fileName, fullArtifactName, parentStepName); err != nil {
 		return err
@@ -317,12 +320,15 @@ func getParentStepName(fullArtifactName, artifactDirectoryPrefix string) (string
 	return parentStepName, nil
 }
 
-func getFileName(fullArtifactName, artifactDirectoryPrefix string) string {
+func getFileName(fullArtifactName, artifactDirectoryPrefix string) (string, error) {
 	sp := strings.Split(fullArtifactName, artifactDirectoryPrefix)
+	if len(sp) != 2 {
+		return "", fmt.Errorf("cannot determine filepath - object name: %s, object prefix: %s", fullArtifactName, artifactDirectoryPrefix)
+	}
 	parentStepFilePath := sp[1]
 
 	sp = strings.Split(parentStepFilePath, "/")
 	fileName := sp[len(sp)-1]
 
-	return fileName
+	return fileName, nil
 }


### PR DESCRIPTION
* Improved the handling of iterator of e2e directory. The changes ensure  that the iterator's pointer is not advanced when checking for
  `iterator.Done`, preventing potential data loss.
* When the first call to `it.Next()` returns `iterator.Done`, that means
  there's no files found within the current directory with given prefix.
* This implies there are no files present within the directory that's
  supposed to store artifacts related to e2e tests.
* So, we initialise a new iterator for a new directory with prefix that
  points to "build-log.txt" file. And accordingly we init the maps.
* This commit also refactors some logic to move them inside a function.

`Signed-off-by: Dheeraj<djodha@redhat.com>`