### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+
+on:
+  release:
+    types: [ created ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: linux
+          goarch: amd64
+          goversion: 1.19
+          binary_name: qe-tools
+          extra_files: config


### PR DESCRIPTION
[KONFLUX-2156](https://issues.redhat.com/browse/KONFLUX-2156)

Add GitHub Action that adds config and built binary to artifacts on creation of a release.

Tested in my fork. 
[Workflow run](https://github.com/tnevrlka/qe-tools/actions/runs/8143301835/job/22254834804)
[Release with artifacts](https://github.com/tnevrlka/qe-tools/releases/tag/v1.1)