### PR TITLE
fix: add label when estimated time is 0 seconds

### DIFF
--- a/cmd/estimate/reviewTime.go
+++ b/cmd/estimate/reviewTime.go
@@ -228,7 +228,7 @@ func getLabelBasedOnTime(reviewTime int) (*TimeLabel, error) {
 	}
 	maxLabel := TimeLabel{Time: -1}
 	for _, label := range config.Labels {
-		if label.Time < reviewTime && label.Time > maxLabel.Time {
+		if label.Time <= reviewTime && label.Time > maxLabel.Time {
 			maxLabel = label
 		}
 	}


### PR DESCRIPTION
The command failed to add a label when estimation was 0 seconds. (one line in .md file is 0.2 seconds which is considered 0)