### PR TITLE
chore: update golang image to 1.22

### DIFF
--- a/.github/workflows/coffee.yml
+++ b/.github/workflows/coffee.yml
@@ -9,7 +9,7 @@ jobs:
   coffee-break:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.19
+      image: golang:1.22
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Using a golang 1.19 container generated the same group everytime, this should be fixed by updating to 1.20 or newer (https://pkg.go.dev/math/rand#Seed)