### PR TITLE
fix: double quote goversion in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: linux
           goarch: amd64
-          goversion: 1.20
+          goversion: "1.20"
           binary_name: qe-tools
           extra_files: config


### PR DESCRIPTION
The release action [failed](https://github.com/redhat-appstudio/qe-tools/actions/runs/8283109912/job/22665522167) due to an unquoted golang version. 
See issue https://github.com/actions/setup-go/issues/326

This should be fixed by double quoting the golang version. 
See the [run after the fix in my fork](https://github.com/tnevrlka/qe-tools/actions/runs/8283830874/job/22667961126)