### PR TITLE
fix: estimate review time unknown file extension edge case

### DIFF
--- a/cmd/estimate/reviewTime.go
+++ b/cmd/estimate/reviewTime.go
@@ -229,7 +229,7 @@ func getLabelBasedOnTime(reviewTime int) (*TimeLabel, error) {
 	}
 	maxLabel := TimeLabel{Time: -1}
 	for _, label := range config.Labels {
-		if label.Time < reviewTime && label.Time > maxLabel.Time {
+		if label.Time <= reviewTime && label.Time > maxLabel.Time {
 			maxLabel = label
 		}
 	}

--- a/cmd/estimate/reviewTime.go
+++ b/cmd/estimate/reviewTime.go
@@ -166,7 +166,8 @@ func estimateFileTimes(files []*github.CommitFile) int {
 		}
 		estimate, included := config.Extensions[extension]
 		if !included {
-			estimate, defaultIncluded := config.Extensions["default"]
+			var defaultIncluded bool
+			estimate, defaultIncluded = config.Extensions["default"]
 			if !defaultIncluded {
 				estimate = defaultExtensionWeight
 			}


### PR DESCRIPTION
Error found in https://github.com/tnevrlka/e2e-tests/actions/runs/8328326228/job/22788032312?pr=9.

* Fix variable estimate not getting set correctly if the file extension is
unknown
* Fix label not getting set correctly when estimated time is 0 seconds