### PR TITLE
fix(KONFLUX-3152): update integration-service reference after migration

### DIFF
--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -281,7 +281,7 @@ func determineJobTargetFromProwJobURL(prowJobURL string) (jobTarget string, err 
 	case strings.Contains(prowJobURL, "pull-ci-redhat-appstudio-e2e-tests"):
 		// prow URL is from e2e-tests repo
 		jobTarget = "redhat-appstudio-e2e"
-	case strings.Contains(prowJobURL, "pull-ci-redhat-appstudio-integration-service"):
+	case strings.Contains(prowJobURL, "pull-ci-konflux-ci-integration-service"):
 		// prow URL is from integration-service repo
 		jobTarget = "integration-service-e2e"
 	default:


### PR DESCRIPTION
ci-helper-app's pod logs are filled with the following kind of errors:
```
{"level":"error","github_event_type":"issue_comment","github_delivery_id":"f12f08f0-16e8-11ef-9760-dd6be81b8c56","github_installation_id":50801697,"github_repository_owner":"konflux-ci","github_repository_name":"integration-service","github_pr_num":736,"prow_job_url":"https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/konflux-ci_integration-service/736/pull-ci-konflux-ci-integration-service-main-integration-service-e2e/1792646493945991168","error":"failed to determine job details: failed to determine job target from Prow job URL: unable to determine the target from the ProwJobURL: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/konflux-ci_integration-service/736/pull-ci-konflux-ci-integration-service-main-integration-service-e2e/1792646493945991168","time":"2024-05-20T20:39:21Z","message":"Failed to scan artifacts from the Prow job...Retrying"}
```
This PR fixes the issue.