### PR TITLE
Update codecov.yml: add ignore patterns for non-code files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,15 @@
 codecov:
   require_ci_to_pass: true
 
+ignore:
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "docs/**"
+  - "*.md"
+  - "*.toml"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
Adds ignore patterns for non-executable files: `.agents/**`, `.claude/**`, `.cursor/**`, `skills/**`, `docs/**`, `*.md`, `*.toml`. Existing config (flags) preserved.

## Why
Non-executable files inflate Codecov's coverage denominator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)